### PR TITLE
src/CMakeLists.txt: GObjectIntrospection is not optional, so mark it …

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -132,7 +132,7 @@ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/lib${ayatana_appindicator_gtkver}.so.
 
 # AyatanaAppIndicator{,3}-0.1.gir
 
-find_package(GObjectIntrospection REQUIRED QUIET)
+find_package(GObjectIntrospection REQUIRED)
 
 add_custom_command(
     OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${ayatana_appindicator_girver}-0.1.gir"


### PR DESCRIPTION
…as REQUIRED (only).

 Fixes https://github.com/AyatanaIndicators/libayatana-appindicator/issues/28