### PR TITLE
Fix build with musl libc

### DIFF
--- a/src/app-indicator.c
+++ b/src/app-indicator.c
@@ -2081,7 +2081,7 @@ append_snap_prefix (const gchar *path)
 	g_autofree gchar *canon_path = NULL;
 
 	if (snap != NULL && path != NULL) {
-		canon_path = canonicalize_file_name(path);
+		canon_path = realpath(path, NULL);
 
 		if (g_str_has_prefix (canon_path, "/tmp/")) {
 			g_warning ("Using '/tmp' paths in SNAP environment will lead to unreadable resources");


### PR DESCRIPTION
canonicalize_file_name() is a GNU extension not supported by musl libc.
Use realpath() from POSIX instead.

---

Pretty much stolen from https://gitlab.freedesktop.org/mobile-broadband/ModemManager/-/commit/105e321951e3303ddf0c9c1df83bc673c92eb7de :wink: 