### PR TITLE
Use /bin/sh for running tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -94,7 +94,7 @@ add_custom_command(
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     VERBATIM
     COMMAND
-    echo "#!/bin/bash" > "${CMAKE_CURRENT_BINARY_DIR}/test-libappindicator-fallback"
+    echo "#!/bin/sh" > "${CMAKE_CURRENT_BINARY_DIR}/test-libappindicator-fallback"
     COMMAND
     echo "export DISPLAY=" >> "${CMAKE_CURRENT_BINARY_DIR}/test-libappindicator-fallback"
     COMMAND
@@ -116,7 +116,7 @@ add_custom_command(
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     VERBATIM
     COMMAND
-    echo "#!/bin/bash" > "${CMAKE_CURRENT_BINARY_DIR}/test-libappindicator-dbus"
+    echo "#!/bin/sh" > "${CMAKE_CURRENT_BINARY_DIR}/test-libappindicator-dbus"
     COMMAND
     echo "export DISPLAY=" >> "${CMAKE_CURRENT_BINARY_DIR}/test-libappindicator-dbus"
     COMMAND
@@ -138,7 +138,7 @@ add_custom_command(
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     VERBATIM
     COMMAND
-    echo "#!/bin/bash" > "${CMAKE_CURRENT_BINARY_DIR}/test-libappindicator-status"
+    echo "#!/bin/sh" > "${CMAKE_CURRENT_BINARY_DIR}/test-libappindicator-status"
     COMMAND
     echo "export DISPLAY=" >> "${CMAKE_CURRENT_BINARY_DIR}/test-libappindicator-status"
     COMMAND
@@ -174,7 +174,7 @@ add_custom_command(
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     VERBATIM
     COMMAND
-    echo "#!/bin/bash" > "${CMAKE_CURRENT_BINARY_DIR}/libappindicator-tests"
+    echo "#!/bin/sh" > "${CMAKE_CURRENT_BINARY_DIR}/libappindicator-tests"
     COMMAND
     echo "export DISPLAY=" >> "${CMAKE_CURRENT_BINARY_DIR}/libappindicator-tests"
     COMMAND


### PR DESCRIPTION
The tests run fine with busybox ash as /bin/sh and do not require bash.