### PR TITLE
cmake: Install library as library

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -126,9 +126,7 @@ target_include_directories("${ayatana_appindicator_gtkver}" PUBLIC ${CMAKE_CURRE
 target_include_directories("${ayatana_appindicator_gtkver}" PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries("${ayatana_appindicator_gtkver}" ${PROJECT_DEPS_LIBRARIES})
 target_link_options ("${ayatana_appindicator_gtkver}" PRIVATE "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/app-indicator.symbols")
-install(FILES "${CMAKE_CURRENT_BINARY_DIR}/lib${ayatana_appindicator_gtkver}.so" DESTINATION "${CMAKE_INSTALL_FULL_LIBDIR}")
-install(FILES "${CMAKE_CURRENT_BINARY_DIR}/lib${ayatana_appindicator_gtkver}.so.1" DESTINATION "${CMAKE_INSTALL_FULL_LIBDIR}")
-install(FILES "${CMAKE_CURRENT_BINARY_DIR}/lib${ayatana_appindicator_gtkver}.so.1.0.0" DESTINATION "${CMAKE_INSTALL_FULL_LIBDIR}")
+install(TARGETS "${ayatana_appindicator_gtkver}" LIBRARY DESTINATION "${CMAKE_INSTALL_FULL_LIBDIR}")
 
 # AyatanaAppIndicator{,3}-0.1.gir
 


### PR DESCRIPTION
Fedora needs libraries to be executable to extract debug information. Debian does not. The cmake TARGETS installation takes care of this, therefore use it.