### PR TITLE
Correct symbols in version script file

### DIFF
--- a/src/app-indicator.symbols
+++ b/src/app-indicator.symbols
@@ -1,6 +1,6 @@
 {
     global: app_indicator_*;
     local:  _notification_*;
-            _generate_;
-            _application_;
+            _generate_id;
+            _application_service_marshal_*;
 };


### PR DESCRIPTION
LLVM lld checks for nonexistent symbols in version scripts files. Correct symbols names to what appears to be the desired results.

Bug: https://bugs.gentoo.org/934481
Fixes: 4d97676bb5ba1a7612aed36d219cbaa978adc90e